### PR TITLE
feat(changelog): adopt changelog.d fragments assembled by scriv

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,61 @@
+# file: .github/workflows/changelog-check.yml
+# version: 1.0.0
+# guid: 28920039-03b2-4852-8754-cd7ba2896ce3
+
+name: Changelog Fragment Check
+
+# Requires a changelog fragment under changelog.d/ on every PR. Self-skips if the
+# repo has no changelog.d/scriv.ini. See changelog.d/README.md.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: changelog-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  require-fragment:
+    name: Require changelog fragment
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Require a changelog fragment
+        run: |
+          set -euo pipefail
+          if [ ! -f changelog.d/scriv.ini ]; then
+            echo "::notice::changelog.d/scriv.ini not present — changelog fragments not enabled here."
+            exit 0
+          fi
+          if [ "${SKIP_LABEL}" = "true" ]; then
+            echo "::notice::'skip-changelog' label present — skipping."
+            exit 0
+          fi
+          case "${PR_TITLE}" in
+            *"[skip changelog]"*)
+              echo "::notice::'[skip changelog]' in PR title — skipping."
+              exit 0 ;;
+          esac
+          git fetch --no-tags origin "${BASE_REF}"
+          added="$(git diff --name-only --diff-filter=A "origin/${BASE_REF}...HEAD" \
+            | { grep -E '^changelog\.d/.*\.md$' || true; } \
+            | { grep -vE '^changelog\.d/(README\.md$|templates/)' || true; })"
+          if [ -n "${added}" ]; then
+            echo "Found changelog fragment(s):"; echo "${added}"; exit 0
+          fi
+          echo "::error::No changelog fragment under changelog.d/. Run 'scriv create'"
+          echo "(see changelog.d/README.md), or add the 'skip-changelog' label or"
+          echo "'[skip changelog]' to the PR title if no changelog entry is needed."
+          exit 1

--- a/.github/workflows/changelog-collect.yml
+++ b/.github/workflows/changelog-collect.yml
@@ -1,0 +1,92 @@
+# file: .github/workflows/changelog-collect.yml
+# version: 1.0.0
+# guid: b0d9c31b-fc98-4b0e-a3ce-294421031757
+
+name: Collect Changelog
+
+# Assembles CHANGELOG.md from changelog.d/ fragments when a stable release is
+# published, then commits the result to the default branch. See
+# changelog.d/README.md.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version heading to collect fragments under (e.g. v1.12.0)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: changelog-collect-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    name: Collect fragments into CHANGELOG.md
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.JF_CI_GH_PAT || github.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: Install scriv
+        run: python3 -m pip install --quiet scriv
+
+      - name: Collect fragments and commit
+        env:
+          VERSION: ${{ github.event.inputs.version || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${VERSION:-}" ]; then
+            echo "::error::No version supplied."
+            exit 1
+          fi
+
+          if [ ! -f CHANGELOG.md ] || ! grep -q 'scriv-insert-here' CHANGELOG.md; then
+            echo "::warning::CHANGELOG.md lacks the scriv-insert-here marker; skipping."
+            exit 0
+          fi
+
+          if ! find changelog.d -maxdepth 1 -name '*.md' ! -name 'README.md' | grep -q .; then
+            echo "::notice::No changelog fragments to collect for ${VERSION}."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          python3 -m pip install --quiet scriv
+          python3 -m scriv collect --version "${VERSION}"
+
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "::notice::scriv produced no changes."
+            exit 0
+          fi
+
+          git add -A CHANGELOG.md changelog.d
+          git commit -m "docs(changelog): collect fragments for ${VERSION} [skip ci]"
+
+          n=0
+          until git push origin "HEAD:${{ github.event.repository.default_branch }}" || [ "$n" -ge 4 ]; do
+            n=$((n + 1))
+            echo "Retry $n/4 for changelog push..."
+            sleep $((2 ** n))
+            git pull --rebase origin "${{ github.event.repository.default_branch }}"
+          done
+          [ "$n" -lt 4 ] || { echo "::error::Failed to push CHANGELOG.md"; exit 1; }
+          echo "CHANGELOG.md updated for ${VERSION}"

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,8 @@
 # Generated files
 workflow-permissions-analysis.json
 **/processed/*.json
+
+# Changelog fragments (partial Markdown assembled into CHANGELOG.md)
+changelog.d/*.md
+changelog.d/templates/**
+!changelog.d/README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- scriv-insert-here -->

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,70 @@
+<!-- file: changelog.d/README.md -->
+<!-- version: 1.1.0 -->
+<!-- guid: 8d3a1f26-4c7b-4e59-b0a2-6f1d9c8e5a34 -->
+<!-- last-edited: 2026-07-16 -->
+
+# Changelog fragments (`changelog.d/`)
+
+`CHANGELOG.md` is **assembled** from the fragment files in this directory — you
+do **not** edit `CHANGELOG.md` by hand. Every change that is worth recording
+drops a small, uniquely-named Markdown fragment here instead. At release time
+the automation folds all fragments into a new dated section of `CHANGELOG.md`
+and deletes them.
+
+This exists because many contributors and AI agents open PRs in parallel. If
+everyone edited the single `## [Unreleased]` block in `CHANGELOG.md` directly,
+every PR would collide. A fragment-per-change means PRs never touch the same
+file, so there are no changelog merge conflicts.
+
+> This is a focused revival of the retired JSON "doc-update" system, using the
+> maintained open-source [`scriv`](https://scriv.readthedocs.io/) tool instead
+> of bespoke scripts.
+
+## Add a fragment
+
+```bash
+pip install scriv           # first time only
+scriv create                # writes changelog.d/<timestamp>_<branch>.md
+```
+
+Open the generated file, uncomment the section(s) that apply, and fill them in.
+You can also just create the file by hand following the format below. A CI check
+fails any PR that changes code without adding a fragment.
+
+## Format
+
+A fragment is a slice of Markdown grouped under Keep a Changelog category
+headings. Give each entry a `####` title and a short explanatory paragraph — a
+changelog carries **more detail than a release note**: what changed, why, and
+any impact or reproduction.
+
+```markdown
+### Fixed
+
+#### Short imperative title for the change
+
+A detailed explanation of the change: what it does, why it was needed, and any
+impact or reproduction detail worth recording.
+```
+
+- **Categories:** `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`,
+  `Security` (Keep a Changelog).
+- **Conventional-commit → category:** `feat` → Added, `fix` → Fixed,
+  `perf`/`refactor` → Changed; deprecations → Deprecated, removals → Removed,
+  security fixes → Security.
+- One fragment per logical change. Use several category sections in one fragment
+  only when a single change genuinely spans them.
+- Fragments are **exempt from the file-header rule** — do not add the
+  `file`/`version`/`guid` header (it would leak into `CHANGELOG.md`).
+
+## How assembly works
+
+- `scriv collect --version <tag>` (run by `.github/workflows/changelog-collect.yml`
+  when a release is published) inserts a new `## <version> — <date>` section at
+  the `<!-- scriv-insert-here -->` marker in `CHANGELOG.md`, grouped by category,
+  and removes the collected fragments.
+- The PR fragment check comes from `.github/workflows/changelog-check.yml`.
+- Configuration lives in [`scriv.ini`](scriv.ini); the new-fragment scaffold is
+  [`templates/new_fragment.md.j2`](templates/new_fragment.md.j2).
+- GitHub **release notes** stay commit-based; this detailed changelog is the
+  separate, richer artifact.

--- a/changelog.d/adopt-changelog-fragments.md
+++ b/changelog.d/adopt-changelog-fragments.md
@@ -1,0 +1,9 @@
+### Changed
+
+#### Adopt changelog fragments (`changelog.d/`) for assembling CHANGELOG.md
+
+`CHANGELOG.md` is now assembled from per-change Markdown fragments under
+`changelog.d/` by `scriv`, instead of being edited by hand. Contributors add a
+fragment with `scriv create`; a CI check requires one on each PR, and the
+fragments are folded into `CHANGELOG.md` when a release is published. This
+removes changelog merge conflicts across parallel PRs.

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,22 @@
+# file: changelog.d/scriv.ini
+# version: 1.0.0
+# guid: 5b1c9a7e-0d2f-4a63-9c81-3e6f4b2a8d10
+
+# scriv configuration for assembling CHANGELOG.md from changelog fragments.
+# https://scriv.readthedocs.io/  —  self-contained here so the repo root
+# stays free of a pyproject.toml just for this tool.
+[scriv]
+# Markdown fragments/output, matching the existing hand-written CHANGELOG.md.
+format = md
+output_file = CHANGELOG.md
+fragment_directory = changelog.d
+
+# Version heading renders at level 2 (## X.Y.Z — date), categories at level 3
+# (### Added), matching Keep a Changelog and the existing file structure.
+md_header_level = 2
+
+# Keep a Changelog categories, in the order they should appear in each release.
+categories = Added, Changed, Deprecated, Removed, Fixed, Security
+
+# Custom scaffold produced by `scriv create` (see templates/new_fragment.md.j2).
+new_fragment_template = file: changelog.d/templates/new_fragment.md.j2

--- a/changelog.d/templates/new_fragment.md.j2
+++ b/changelog.d/templates/new_fragment.md.j2
@@ -1,0 +1,29 @@
+{#- Scaffold rendered by `scriv create`. Do NOT add a file header here — the -#}
+{#- rendered output is concatenated into CHANGELOG.md verbatim, so a header -#}
+{#- would leak into the changelog. -#}
+<!--
+Add ONE fragment per logical change. Uncomment the section(s) that apply below
+and replace the placeholder text, then delete the sections you do not use.
+
+A changelog entry carries MORE detail than a release note: state what changed,
+why, and any impact or reproduction — mirror the "#### short title" +
+explanatory paragraph style already used in CHANGELOG.md.
+
+Conventional-commit type -> category:
+  feat -> Added        fix -> Fixed         perf, refactor -> Changed
+  (deprecations -> Deprecated, removals -> Removed, security fixes -> Security)
+
+Leave every section commented out for a release-note-only entry (no changelog
+line). This file is auto-named and unique, so it never conflicts with other
+contributors' fragments.
+-->
+{% for cat in config.categories -%}
+<!--
+### {{ cat }}
+
+#### Short imperative title for the change
+
+A detailed explanation of the change: what it does, why it was needed, and any
+impact, migration note, or reproduction detail worth recording.
+-->
+{% endfor -%}


### PR DESCRIPTION
## Summary

Adopts the org-wide changelog-fragments system. Each change drops a Markdown fragment under `changelog.d/` instead of hand-editing `CHANGELOG.md`; [`scriv`](https://scriv.readthedocs.io/) folds them into `CHANGELOG.md` when a release is published — so parallel PRs never collide on the changelog. This repo had no `CHANGELOG.md`, so a fresh Keep a Changelog file is added.

## Files Modified

- `CHANGELOG.md` — new Keep a Changelog file with the `scriv-insert-here` marker
- `changelog.d/{scriv.ini,templates/new_fragment.md.j2,README.md}` — scaffolding
- `changelog.d/adopt-changelog-fragments.md` — seed fragment
- `.github/workflows/changelog-check.yml` — require a fragment on PRs
- `.github/workflows/changelog-collect.yml` — assemble `CHANGELOG.md` on release published
- `.prettierignore` — exclude partial fragments

## Testing

`scriv collect --version v0.0.0-test` assembles the seed fragment into a `## v0.0.0-test` section at the marker. The PR carries a fragment, so `changelog-check.yml` passes. Run `scriv create` for future entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsNZiDgk29rvsrk5aWsqDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsNZiDgk29rvsrk5aWsqDW)_